### PR TITLE
#28478 Add handling for Nuke 9 knob name change from codec to meta_codec

### DIFF
--- a/python/tk_multi_reviewsubmission/renderer.py
+++ b/python/tk_multi_reviewsubmission/renderer.py
@@ -164,14 +164,19 @@ class Renderer(object):
         #
         # These are either hard coded by a studio in a quicktime generation app
         # itself (like here) or part of the configuration - however there is
-        # often the need to have special rules to for example handle multi
+        # often the need to have special rules to, for example, handle multi
         # platform cases.
         #
 
         if sys.platform in ["darwin", "win32"]:
             # On the mac and windows, we use the quicktime codec
             node["file_type"].setValue("mov")
-            node["codec"].setValue("jpeg")
+            # Nuke 9.0v1 changed the codec knob name and added an encoder knob
+            # (which defaults to the new mov64 encoder/decoder) 
+            if not node.knob["codec"].setValue("jpeg"):
+                node["meta_codec"].setValue("jpeg")
+            else:
+                node["codec"].setValue("jpeg")
 
         elif sys.platform == "linux2":
             # On linux, use ffmpeg

--- a/python/tk_multi_reviewsubmission/renderer.py
+++ b/python/tk_multi_reviewsubmission/renderer.py
@@ -173,7 +173,7 @@ class Renderer(object):
             node["file_type"].setValue("mov")
             # Nuke 9.0v1 changed the codec knob name and added an encoder knob
             # (which defaults to the new mov64 encoder/decoder) 
-            if not node.knob["codec"].setValue("jpeg"):
+            if "meta_codec" in node.knobs():
                 node["meta_codec"].setValue("jpeg")
             else:
                 node["codec"].setValue("jpeg")


### PR DESCRIPTION
Nuke 9.0v1 introduced some Quicktime changes/improvements. One side effect is that they renamed the `codec` knob to `meta_codec` when writing Quicktime files (*note this is still undocumented in the Nuke User Guide and Node Reference as of v9.0v4*). This change checks if setting the `codec` knob succeeds. If not, it uses `meta_codec` for the knob name.