### PR TITLE
#25764 Move the Quicktime generation settings into a hook

### DIFF
--- a/hooks/codec_settings.py
+++ b/hooks/codec_settings.py
@@ -1,24 +1,29 @@
 # Copyright (c) 2015 Shotgun Software Inc.
-#
+# 
 # CONFIDENTIAL AND PROPRIETARY
-#
-# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# 
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
 # Source Code License included in this distribution package. See LICENSE.
-# By accessing, using, copying or modifying this work you indicate your
-# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# By accessing, using, copying or modifying this work you indicate your 
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
+"""
+Hook that controls various codec settings when submitting items for review
+"""
+import sgtk
+import os
 import sys
 
-from tank import Hook
 import nuke
 
-class ReviewSubmissionGetQuicktimeSettings(Hook):
-    """
-    Allows modifying default settings for Quicktime generation.
-    """
-    def execute(self, **kwargs):
+HookBaseClass = sgtk.get_hook_baseclass()
+
+class CodecSettings(HookBaseClass):
+
+    def get_quicktime_settings(self, **kwargs):
         """
+        Allows modifying default codec settings for Quicktime generation.
         Returns a dictionary of settings to be used for the Write Node that generates
         the Quicktime in Nuke.
         """

--- a/hooks/codec_settings.py
+++ b/hooks/codec_settings.py
@@ -29,19 +29,24 @@ class CodecSettings(HookBaseClass):
         """
         settings = {}
         if sys.platform in ["darwin", "win32"]:
-            # On Mac and Windows, we use the Quicktime codec
             settings["file_type"] = "mov"
-            # Nuke 9.0v1 changed the codec knob name to meta_codec and added an encoder knob
-            # (which defaults to the new mov64 encoder/decoder).  
-            if nuke.NUKE_VERSION_MAJOR > 8:
+            if nuke.NUKE_VERSION_MAJOR >= 9:
+                # Nuke 9.0v1 changed the codec knob name to meta_codec and added an encoder knob
+                # (which defaults to the new mov64 encoder/decoder).                  
                 settings["meta_codec"] = "jpeg"
             else:
                 settings["codec"] = "jpeg"
 
         elif sys.platform == "linux2":
-            # On linux, use ffmpeg
-            settings["file_type"] = "ffmpeg"
-            settings["format"] = "MOV format (mov)"
+            if nuke.NUKE_VERSION_MAJOR >= 9:
+                # Nuke 9.0v1 removed ffmpeg and replaced it with the mov64 writer
+                # http://help.thefoundry.co.uk/nuke/9.0/#appendices/appendixc/supported_file_formats.html
+                settings["file_type"] = "mov64"
+                settings["mov64_codec"] = "jpeg"
+            else:
+                # the 'codec' knob name was changed to 'format' in Nuke 7.0
+                settings["file_type"] = "ffmpeg"
+                settings["format"] = "MOV format (mov)"
 
         return settings
 

--- a/hooks/reviewsubmission_quicktime_settings.py
+++ b/hooks/reviewsubmission_quicktime_settings.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2015 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+import sys
+
+from tank import Hook
+import nuke
+
+class ReviewSubmissionGetQuicktimeSettings(Hook):
+    """
+    Allows modifying default settings for Quicktime generation.
+    """
+    def execute(self, **kwargs):
+        """
+        Returns a dictionary of settings to be used for the Write Node that generates
+        the Quicktime in Nuke.
+        """
+        settings = {}
+        if sys.platform in ["darwin", "win32"]:
+            # On Mac and Windows, we use the Quicktime codec
+            settings["file_type"] = "mov"
+            # Nuke 9.0v1 changed the codec knob name to meta_codec and added an encoder knob
+            # (which defaults to the new mov64 encoder/decoder).  
+            if nuke.NUKE_VERSION_MAJOR > 8:
+                settings["meta_codec"] = "jpeg"
+            else:
+                settings["codec"] = "jpeg"
+
+        elif sys.platform == "linux2":
+            # On linux, use ffmpeg
+            settings["file_type"] = "ffmpeg"
+            settings["format"] = "MOV format (mov)"
+
+        return settings
+

--- a/info.yml
+++ b/info.yml
@@ -76,13 +76,11 @@ configuration:
                      setting is an empty string, no logo will be applied.
         default_value: ""
 
-    hook_reviewsubmission_quicktime_settings:
+    codec_settings_hook:
         type: hook
-        description: "Called when generating the default settings for creating
-                     a Quicktime. The return value is a dictionary where the
-                     keys are knob names for the write node, and the values are
-                     the corresponding node values."
-        default_value: reviewsubmission_quicktime_settings
+        description: Hook for customizing codec settings used when generating items
+                     for review.
+        default_value: '{self}/codec_settings.py'
 
 # the Shotgun fields that this app needs in order to operate correctly
 requires_shotgun_fields:

--- a/info.yml
+++ b/info.yml
@@ -76,6 +76,14 @@ configuration:
                      setting is an empty string, no logo will be applied.
         default_value: ""
 
+    hook_reviewsubmission_quicktime_settings:
+        type: hook
+        description: "Called when generating the default settings for creating
+                     a Quicktime. The return value is a dictionary where the
+                     keys are knob names for the write node, and the values are
+                     the corresponding node values."
+        default_value: reviewsubmission_quicktime_settings
+
 # the Shotgun fields that this app needs in order to operate correctly
 requires_shotgun_fields:
 

--- a/python/tk_multi_reviewsubmission/renderer.py
+++ b/python/tk_multi_reviewsubmission/renderer.py
@@ -159,7 +159,8 @@ class Renderer(object):
         Create the Nuke output node for the movie.
         """
         # get the Write node settings we'll use for generating the Quicktime
-        wn_settings = self.__app.execute_hook("hook_reviewsubmission_quicktime_settings")
+        wn_settings = self.__app.execute_hook_method("codec_settings_hook", 
+                                                     "get_quicktime_settings")
         node = nuke.nodes.Write(**wn_settings)
         
         # Don't fail if we're in proxy mode. The default Nuke publish will fail if

--- a/python/tk_multi_reviewsubmission/renderer.py
+++ b/python/tk_multi_reviewsubmission/renderer.py
@@ -158,31 +158,10 @@ class Renderer(object):
         """
         Create the Nuke output node for the movie.
         """
-        node = nuke.nodes.Write()
-
-        # Example output settings
-        #
-        # These are either hard coded by a studio in a quicktime generation app
-        # itself (like here) or part of the configuration - however there is
-        # often the need to have special rules to, for example, handle multi
-        # platform cases.
-        #
-
-        if sys.platform in ["darwin", "win32"]:
-            # On the mac and windows, we use the quicktime codec
-            node["file_type"].setValue("mov")
-            # Nuke 9.0v1 changed the codec knob name and added an encoder knob
-            # (which defaults to the new mov64 encoder/decoder) 
-            if "meta_codec" in node.knobs():
-                node["meta_codec"].setValue("jpeg")
-            else:
-                node["codec"].setValue("jpeg")
-
-        elif sys.platform == "linux2":
-            # On linux, use ffmpeg
-            node["file_type"].setValue("ffmpeg")
-            node["format"].setValue("MOV format (mov)")
-
+        # get the Write node settings we'll use for generating the Quicktime
+        wn_settings = self.__app.execute_hook("hook_reviewsubmission_quicktime_settings")
+        node = nuke.nodes.Write(**wn_settings)
+        
         # Don't fail if we're in proxy mode. The default Nuke publish will fail if
         # you try and publish while in proxy mode. But in earlier versions of 
         # tk-multi-publish (< v0.6.9) if there is no proxy template set, it falls 


### PR DESCRIPTION
Allows studios to easily override the default output settings when generating movies to submit to Screening Room.