### PR TITLE
#34266 defer applying additional knob settings until after node creation

### DIFF
--- a/python/tk_multi_reviewsubmission/renderer.py
+++ b/python/tk_multi_reviewsubmission/renderer.py
@@ -161,7 +161,14 @@ class Renderer(object):
         # get the Write node settings we'll use for generating the Quicktime
         wn_settings = self.__app.execute_hook_method("codec_settings_hook", 
                                                      "get_quicktime_settings")
-        node = nuke.nodes.Write(**wn_settings)
+
+        node = nuke.nodes.Write(file_type=wn_settings.get("file_type"))
+        
+        # apply any additional knob settings provided by the hook. Now that the knob has been 
+        # created, we can be sure specific file_type settings will be valid.
+        for knob_name, knob_value in wn_settings.iteritems():
+            if knob_name != "file_type":
+                node.knob(knob_name).setValue(knob_value)
         
         # Don't fail if we're in proxy mode. The default Nuke publish will fail if
         # you try and publish while in proxy mode. But in earlier versions of 


### PR DESCRIPTION
There are a lot of knob settings that are specific to the particular `file_type` of the Write node. Previously we were creating the node by passing in all of the settings at once which was generating errors if Nuke tried to set the knob before the `file_type` had been set. This change creates the node with the `file_type` setting, and then applies the rest of the settings from the codec_settings hook afterwards.