### PR TITLE
#35198: Log metrics for apps launched outside of registered command framework

### DIFF
--- a/app.py
+++ b/app.py
@@ -131,4 +131,15 @@ class MultiReviewSubmissionApp(sgtk.platform.Application):
             progress_cb(90, "Deleting rendered movie")
             os.unlink(output_path)
 
+        # log metrics for this app's usage
+        try:
+            self.log_metric("Render & Submit Version")
+            self.engine.log_user_attribute_metric(
+                "%s version" % (self.name,),
+                self.version
+            )
+        except:
+            # ingore any errors. ex: metrics logging not supported
+            pass
+
         return sg_version

--- a/app.py
+++ b/app.py
@@ -133,11 +133,7 @@ class MultiReviewSubmissionApp(sgtk.platform.Application):
 
         # log metrics for this app's usage
         try:
-            self.log_metric("Render & Submit Version")
-            self.engine.log_user_attribute_metric(
-                "%s version" % (self.name,),
-                self.version
-            )
+            self.log_metric("Render & Submit Version", log_version=True)
         except:
             # ingore any errors. ex: metrics logging not supported
             pass


### PR DESCRIPTION
This change logs the app version and one action metric for "review & submit version".