### PR TITLE
Modify Read node creation to allow for MOVs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ pip-log.txt
 
 #Mr Developer
 .mr.developer.cfg
+
+#PyCharm
+.idea/
+

--- a/python/tk_multi_reviewsubmission/renderer.py
+++ b/python/tk_multi_reviewsubmission/renderer.py
@@ -79,8 +79,9 @@ class Renderer(object):
             else:
                 read['frame_mode'].setValue('start at')
                 read['frame'].setValue(str(first_frame))
-            if color_space:
-                read["colorspace"].setValue(color_space)
+            # if color_space:
+            #     read["colorspace"].setValue(color_space)
+            read["raw"].setValue(True)
             
             # now create the slate/burnin node
             burn = nuke.nodePaste(self._burnin_nk) 

--- a/python/tk_multi_reviewsubmission/renderer.py
+++ b/python/tk_multi_reviewsubmission/renderer.py
@@ -67,10 +67,18 @@ class Renderer(object):
         group.begin()
         try:
             # create read node
-            read = nuke.nodes.Read(name="source", file=path.replace(os.sep, "/"))
+#             read = nuke.nodes.Read(name="source", file=path.replace(os.sep, "/"))
+            read = nuke.nodes.Read(name="source")
+            read['file'].fromUserText(path.replace(os.sep, "/"))
             read["on_error"].setValue("black")
-            read["first"].setValue(first_frame)
-            read["last"].setValue(last_frame)
+            for item in read.knobs():
+                print item
+            if not read.knob('decoder'):
+                read["first"].setValue(first_frame)
+                read["last"].setValue(last_frame)
+            else:
+                read['frame_mode'].setValue('start at')
+                read['frame'].setValue(str(first_frame))
             if color_space:
                 read["colorspace"].setValue(color_space)
             


### PR DESCRIPTION
Adding code to check for the knob "decoder", and using different methods to handle the frame numbers. This allows MOVs to be published and turned into Versions like any other kind of Write node