### PR TITLE
Improve error handling on the case where Shotgun Create is not installed

### DIFF
--- a/python/tk_multi_reviewsubmission/__init__.py
+++ b/python/tk_multi_reviewsubmission/__init__.py
@@ -10,10 +10,17 @@
 
 from .actions import Actions
 
+import sgtk
+
+logger = sgtk.platform.get_logger(__name__)
+
 
 def send_for_review():
-    action = Actions()
-    action.render_and_submit_version()
+    try:
+        action = Actions()
+        action.render_and_submit_version()
+    except RuntimeError as e:
+        logger.error(str(e))
 
 
 def render_and_submit_version(
@@ -30,18 +37,21 @@ def render_and_submit_version(
     *args,
     **kwargs
 ):
-    action = Actions()
-    action.render_and_submit_version(
-        template,
-        fields,
-        first_frame,
-        last_frame,
-        sg_publishes,
-        sg_task,
-        comment,
-        thumbnail_path,
-        progress_cb,
-        color_space,
-        *args,
-        **kwargs
-    )
+    try:
+        action = Actions()
+        action.render_and_submit_version(
+            template,
+            fields,
+            first_frame,
+            last_frame,
+            sg_publishes,
+            sg_task,
+            comment,
+            thumbnail_path,
+            progress_cb,
+            color_space,
+            *args,
+            **kwargs
+        )
+    except Exception as e:
+        logger.error(str(e))

--- a/python/tk_multi_reviewsubmission/__init__.py
+++ b/python/tk_multi_reviewsubmission/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 201 Shotgun Software Inc.
+# Copyright (c) 2019 Shotgun Software Inc.
 #
 # CONFIDENTIAL AND PROPRIETARY
 #


### PR DESCRIPTION
DESCRIPTION

When Shotgun Create is not installed and someone try to use this app's command,
it print an error in the console saying that it didn't worked because Shotgun
Create is not installed.

We should not print the callstack in the logs since it looks like something
went wrong even if it's a regular usecase.