### PR TITLE
Set the currently loaded file as default media name

### DIFF
--- a/hooks/render_media.py
+++ b/hooks/render_media.py
@@ -128,6 +128,6 @@ class RenderMedia(HookBaseClass):
             suffix = extension
 
         with tempfile.NamedTemporaryFile(
-            delete=False, prefix=name + "_", suffix=suffix
+            delete=False, prefix=name + ".", suffix=suffix
         ) as temp_file:
             return temp_file.name

--- a/hooks/tk-maya/render_media.py
+++ b/hooks/tk-maya/render_media.py
@@ -45,13 +45,20 @@ class RenderMedia(HookBaseClass):
         :rtype:                 str
         """
         # For more informations about the playblast API,
-        # http://download.autodesk.com/us/maya/2011help/CommandsPython/playblast.html
+        # https://help.autodesk.com/view/MAYAUL/2020/ENU/?guid=__CommandsPython_playblast_html
 
         playblast_args = {
             "viewer": False,  # Specify whether a viewer should be launched for the playblast.
             "forceOverwrite": True,  # Overwrite existing playblast files which may have the the same name as the one specified with the "-f" flag
             "format": "qt",  # The format of the output of this playblast.
+            "percent": 100,  # Percentage of current view size to use during blasting.
         }
+
+        if name == "Unnamed":
+            current_file_path = maya.cmds.file(query=True, sn=true)
+
+            if current_file_path:
+                name = os.path.basename(current_file_path)
 
         if not output_path:
             output_path = self._get_temp_media_path(name, version, ".mov")

--- a/hooks/tk-maya/render_media.py
+++ b/hooks/tk-maya/render_media.py
@@ -11,6 +11,7 @@
 
 import sgtk
 import maya
+import os
 
 HookBaseClass = sgtk.get_hook_baseclass()
 
@@ -55,7 +56,7 @@ class RenderMedia(HookBaseClass):
         }
 
         if name == "Unnamed":
-            current_file_path = maya.cmds.file(query=True, sn=true)
+            current_file_path = maya.cmds.file(query=True, sn=True)
 
             if current_file_path:
                 name = os.path.basename(current_file_path)

--- a/hooks/tk-photoshopcc/render_media.py
+++ b/hooks/tk-photoshopcc/render_media.py
@@ -15,6 +15,40 @@ HookBaseClass = sgtk.get_hook_baseclass()
 
 
 class RenderMedia(HookBaseClass):
+    def pre_render(
+        self,
+        input_path,
+        output_path,
+        width,
+        height,
+        first_frame,
+        last_frame,
+        version,
+        name,
+        color_space,
+    ):
+        """
+        Callback executed before the media rendering
+
+        :param path:            Path to the input frames for the movie
+        :param output_path:     Path to the output movie that will be rendered
+        :param width:           Width of the output movie
+        :param height:          Height of the output movie
+        :param first_frame:     The first frame of the sequence of frames.
+        :param last_frame:      The last frame of the sequence of frames.
+        :param version:         Version number to use for the output movie slate and burn-in
+        :param name:            Name to use in the slate for the output movie
+        :param color_space:     Colorspace of the input frames
+
+        :returns:               Location of the rendered media
+        :rtype:                 str
+        """
+
+        engine = sgtk.platform.current_engine()
+
+        if not engine.adobe.get_active_document():
+            raise RuntimeError("No active document found.")
+
     def render(
         self,
         input_path,
@@ -43,13 +77,16 @@ class RenderMedia(HookBaseClass):
         :returns:               Location of the rendered media
         :rtype:                 str
         """
+        engine = sgtk.platform.current_engine()
+
+        if name == "Unnamed":
+            name = engine.adobe.get_active_document().name
 
         if not output_path:
             output_path = self._get_temp_media_path(name, version, ".jpg")
 
         self.logger.info("Saving as a JPG to: %s " % output_path)
 
-        engine = sgtk.platform.current_engine()
         output_path = engine.export_as_jpeg(None, output_path)
 
         self.logger.info("JPG written")


### PR DESCRIPTION
JIRA: VMR-2289

DESCRIPTION

Instead of setting the media name to Unnamed if no name is specified, try to set the name of the rendered media file to the name of the currently loaded file in the DCC.
( with the tempfile hash and extension )