### PR TITLE
Restore the behaviour of the app

### DIFF
--- a/hooks/render_media.py
+++ b/hooks/render_media.py
@@ -16,6 +16,10 @@ HookBaseClass = sgtk.get_hook_baseclass()
 
 
 class RenderMedia(HookBaseClass):
+    """
+    Base class of the RenderMedia hook. It implements the hook interface and helper methods.
+    """
+
     def render(
         self,
         input_path,
@@ -31,15 +35,15 @@ class RenderMedia(HookBaseClass):
         """
         Render the media
 
-        :param path:            Path to the input frames for the movie      (Unused)
-        :param output_path:     Path to the output movie that will be rendered
-        :param width:           Width of the output movie                   (Unused)
-        :param height:          Height of the output movie                  (Unused)
-        :param first_frame:     The first frame of the sequence of frames.  (Unused)
-        :param last_frame:      The last frame of the sequence of frames.   (Unused)
-        :param version:         Version number to use for the output movie slate and burn-in
-        :param name:            Name to use in the slate for the output movie
-        :param color_space:     Colorspace of the input frames              (Unused)
+        :param str path:            Path to the input frames for the movie      (Unused)
+        :param str output_path:     Path to the output movie that will be rendered
+        :param int width:           Width of the output movie                   (Unused)
+        :param int height:          Height of the output movie                  (Unused)
+        :param int first_frame:     The first frame of the sequence of frames.  (Unused)
+        :param int last_frame:      The last frame of the sequence of frames.   (Unused)
+        :param int version:         Version number to use for the output movie slate and burn-in
+        :param str name:            Name to use in the slate for the output movie
+        :param str color_space:     Colorspace of the input frames              (Unused)
 
         :returns:               Location of the rendered media
         :rtype:                 str
@@ -61,15 +65,15 @@ class RenderMedia(HookBaseClass):
         """
         Callback executed before the media rendering
 
-        :param path:            Path to the input frames for the movie
-        :param output_path:     Path to the output movie that will be rendered
-        :param width:           Width of the output movie
-        :param height:          Height of the output movie
-        :param first_frame:     The first frame of the sequence of frames.
-        :param last_frame:      The last frame of the sequence of frames.
-        :param version:         Version number to use for the output movie slate and burn-in
-        :param name:            Name to use in the slate for the output movie
-        :param color_space:     Colorspace of the input frames
+        :param str path:            Path to the input frames for the movie
+        :param str output_path:     Path to the output movie that will be rendered
+        :param int width:           Width of the output movie
+        :param int height:          Height of the output movie
+        :param int first_frame:     The first frame of the sequence of frames.
+        :param int last_frame:      The last frame of the sequence of frames.
+        :param int version:         Version number to use for the output movie slate and burn-in
+        :param str name:            Name to use in the slate for the output movie
+        :param str color_space:     Colorspace of the input frames
 
         :returns:               Location of the rendered media
         :rtype:                 str
@@ -92,15 +96,15 @@ class RenderMedia(HookBaseClass):
         """
         Callback executed after the media rendering
 
-        :param input_path:      Path to the input frames for the movie
-        :param output_path:     Path to the output movie that will be rendered
-        :param width:           Width of the output movie
-        :param height:          Height of the output movie
-        :param first_frame:     The first frame of the sequence of frames.
-        :param last_frame:      The last frame of the sequence of frames.
-        :param version:         Version number to use for the output movie slate and burn-in
-        :param name:            Name to use in the slate for the output movie
-        :param color_space:     Colorspace of the input frames
+        :param str input_path:      Path to the input frames for the movie
+        :param str output_path:     Path to the output movie that will be rendered
+        :param int width:           Width of the output movie
+        :param int height:          Height of the output movie
+        :param int first_frame:     The first frame of the sequence of frames.
+        :param int last_frame:      The last frame of the sequence of frames.
+        :param int version:         Version number to use for the output movie slate and burn-in
+        :param str name:            Name to use in the slate for the output movie
+        :param str color_space:     Colorspace of the input frames
 
         :returns:               Location of the rendered media
         :rtype:                 str
@@ -112,9 +116,9 @@ class RenderMedia(HookBaseClass):
         """
         Build a temporary path to put the rendered media.
 
-        :param name:            Name of the media being rendered
-        :param version:         Version number of the media being rendered
-        :param extension:       Extension of the media being rendered
+        :param str name:            Name of the media being rendered
+        :param str version:         Version number of the media being rendered
+        :param str extension:       Extension of the media being rendered
 
         :returns:               Temporary path to put the rendered version
         :rtype:                 str

--- a/hooks/submitter_create.py
+++ b/hooks/submitter_create.py
@@ -15,6 +15,10 @@ HookBaseClass = sgtk.get_hook_baseclass()
 
 
 class SubmitterCreate(HookBaseClass):
+    """
+    This hook allow to submit a Version to Shotgun using Shotgun Create.
+    """
+
     def __init__(self, *args, **kwargs):
         super(SubmitterCreate, self).__init__(*args, **kwargs)
 
@@ -57,16 +61,19 @@ class SubmitterCreate(HookBaseClass):
         last_frame,
     ):
         """
-        Create a version in Shotgun for this path and linked to this publish.
+        Create a version in Shotgun for a given path and linked to the specified publishes.
 
-        :param path_to_frames: Path to the frame representation.
-        :param path_to_movie: Path to the movie representation.
-        :param thumbnail_path: Path to the thumbnail representing. ( Unused )
-        :param sg_publishes: Published files that have to be linked to the version.
-        :param sg_task: Task that have to be linked to the version.
-        :param description: Description of the version.
-        :param first_frame: Version first frame ( Unused )
-        :param last_frame: Version last frame ( Unused )
+        :param str path_to_frames: Path to the frames.
+        :param str path_to_movie: Path to the movie.
+        :param str thumbnail_path: Path to the thumbnail representing the version. ( Unused )
+        :param list(dict) sg_publishes: Published files that have to be linked to the version.
+        :param dict sg_task: Task that have to be linked to the version.
+        :param str description: Description of the version.
+        :param int first_frame: Version first frame ( Unused )
+        :param int last_frame: Version last frame ( Unused )
+
+        Note: Shotgun Create will create the thumbnail for the movie passed in and
+        will inspect the media to get the first and last frame, so these parameters are ignored.
 
         :returns:               Location of the rendered media
         :rtype:                 str

--- a/hooks/submitter_create.py
+++ b/hooks/submitter_create.py
@@ -1,0 +1,101 @@
+# Copyright (c) 2020 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+
+import sgtk
+
+HookBaseClass = sgtk.get_hook_baseclass()
+
+
+class SubmitterCreate(HookBaseClass):
+    def __init__(self, *args, **kwargs):
+        super(SubmitterCreate, self).__init__(*args, **kwargs)
+
+        self.__app = self.parent
+
+        desktopclient_framework = self.load_framework(
+            "tk-framework-desktopclient_v0.x.x"
+        )
+        self.__create_client_module = desktopclient_framework.import_module(
+            "create_client"
+        )
+
+    def can_submit(self):
+        """
+        Checks if it's possible to submit versions given the current context/environment.
+
+        :returns:               Flag telling if the hook can submit a version.
+        :rtype:                 bool
+        """
+
+        if not self.__create_client_module.is_create_installed():
+            self.log_warning("Shotgun Create is not installed.")
+            self.__create_client_module.open_shotgun_create_download_page(
+                self.__app.sgtk.shotgun
+            )
+
+            return False
+
+        return True
+
+    def submit_version(
+        self,
+        path_to_frames,
+        path_to_movie,
+        thumbnail_path,
+        sg_publishes,
+        sg_task,
+        description,
+        first_frame,
+        last_frame,
+    ):
+        """
+        Create a version in Shotgun for this path and linked to this publish.
+
+        :param path_to_frames: Path to the frame representation.
+        :param path_to_movie: Path to the movie representation.
+        :param thumbnail_path: Path to the thumbnail representing. ( Unused )
+        :param sg_publishes: Published files that have to be linked to the version.
+        :param sg_task: Task that have to be linked to the version.
+        :param description: Description of the version.
+        :param first_frame: Version first frame ( Unused )
+        :param last_frame: Version last frame ( Unused )
+
+        :returns:               Location of the rendered media
+        :rtype:                 str
+        """
+
+        path_to_media = path_to_movie or path_to_frames
+
+        # Starts Shotgun Create in the right context if not already running.
+        ok = self.__create_client_module.ensure_create_server_is_running(
+            self.__app.sgtk.shotgun
+        )
+
+        if not ok:
+            raise RuntimeError("Unable to connect to Shotgun Create.")
+
+        client = self.__create_client_module.CreateClient(self.__app.sgtk.shotgun)
+
+        if not sg_task:
+            sg_task = self.__app.context.task
+
+        version_draft_args = dict()
+        version_draft_args["task_id"] = sg_task["id"]
+        version_draft_args["path"] = path_to_media
+        version_draft_args["version_data"] = dict()
+
+        if sg_publishes:
+            version_draft_args["version_data"]["published_files"] = sg_publishes
+
+        if description:
+            version_draft_args["version_data"]["description"] = description
+
+        client.call_server_method("sgc_open_version_draft", version_draft_args)

--- a/hooks/submitter_sgtk.py
+++ b/hooks/submitter_sgtk.py
@@ -1,0 +1,208 @@
+# Copyright (c) 2020 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+
+import sgtk
+import os
+from sgtk.platform.qt import QtCore
+
+HookBaseClass = sgtk.get_hook_baseclass()
+
+
+class SubmitterSGTK(HookBaseClass):
+    def __init__(self, *args, **kwargs):
+        super(SubmitterSGTK, self).__init__(*args, **kwargs)
+
+        self.__app = self.parent
+
+        self._upload_to_shotgun = self.__app.get_setting("upload_to_shotgun")
+        self._store_on_disk = self.__app.get_setting("store_on_disk")
+
+        if not self._upload_to_shotgun and not self._store_on_disk:
+            self.__app.log_warning(
+                "App is not configured to store images on disk nor upload to shotgun!"
+            )
+
+    def can_submit(self):
+        """
+        Checks if it's possible to submit versions given the current context/environment.
+
+        :returns:               Flag telling if the hook can submit a version.
+        :rtype:                 bool
+        """
+
+        if not self._upload_to_shotgun and not self._store_on_disk:
+            self.log_warning(
+                "App is not configured to store images on disk nor upload to shotgun!"
+            )
+
+            return False
+
+        return True
+
+    def submit_version(
+        self,
+        path_to_frames,
+        path_to_movie,
+        thumbnail_path,
+        sg_publishes,
+        sg_task,
+        description,
+        first_frame,
+        last_frame,
+    ):
+        """
+        Create a version in Shotgun for this path and linked to this publish.
+
+        :param path_to_frames: Path to the frame representation.
+        :param path_to_movie: Path to the movie representation.
+        :param thumbnail_path: Path to the thumbnail representing.
+        :param sg_publishes: Published files that have to be linked to the version.
+        :param sg_task: Task that have to be linked to the version.
+        :param description: Description of the version.
+        :param first_frame: Version first frame.
+        :param last_frame: Version last frame.
+
+        :returns:               Location of the rendered media
+        :rtype:                 str
+        """
+
+        # get current shotgun user
+        current_user = sgtk.util.get_current_user(self.__app.sgtk)
+
+        # create a name for the version based on the file name
+        # grab the file name, strip off extension
+        name = os.path.splitext(os.path.basename(path_to_movie))[0]
+        # do some replacements
+        name = name.replace("_", " ")
+        # and capitalize
+        name = name.capitalize()
+
+        # Create the version in Shotgun
+        ctx = self.__app.context
+        data = {
+            "code": name,
+            "sg_status_list": self.__app.get_setting("new_version_status"),
+            "entity": ctx.entity,
+            "sg_task": sg_task,
+            "sg_first_frame": first_frame,
+            "sg_last_frame": last_frame,
+            "sg_frames_have_slate": False,
+            "created_by": current_user,
+            "user": current_user,
+            "description": description,
+            "sg_path_to_frames": path_to_frames,
+            "sg_movie_has_slate": True,
+            "project": ctx.project,
+        }
+
+        if first_frame and last_frame:
+            data["frame_count"] = last_frame - first_frame + 1
+            data["frame_range"] = "%s-%s" % (first_frame, last_frame)
+
+        if sgtk.util.get_published_file_entity_type(self.__app.sgtk) == "PublishedFile":
+            data["published_files"] = sg_publishes
+        else:  # == "TankPublishedFile"
+            if len(sg_publishes) > 0:
+                if len(sg_publishes) > 1:
+                    self.__app.log_warning(
+                        "Only the first publish of %d can be registered for the new version!"
+                        % len(sg_publishes)
+                    )
+                data["tank_published_file"] = sg_publishes[0]
+
+        if self._store_on_disk:
+            data["sg_path_to_movie"] = path_to_movie
+
+        sg_version = self.__app.sgtk.shotgun.create("Version", data)
+        self.__app.log_debug("Created version in shotgun: %s" % str(data))
+
+        # upload files:
+        self._upload_files(sg_version, path_to_movie, thumbnail_path)
+
+        # Remove from filesystem if required
+        if not self._store_on_disk and os.path.exists(path_to_movie):
+            os.unlink(path_to_movie)
+
+        return sg_version
+
+    def _upload_files(self, sg_version, output_path, thumbnail_path):
+        """
+        Upload the required files to Shotgun.
+
+        :param sg_version:      Version to which uploaded files should be linked.
+        :param output_path:     Media to upload to Shotgun.
+        :param thumbnail_path:  Thumbnail to upload to Shotgun.
+        """
+        # Upload in a new thread and make our own event loop to wait for the
+        # thread to finish.
+        event_loop = QtCore.QEventLoop()
+        thread = UploaderThread(
+            self.__app, sg_version, output_path, thumbnail_path, self._upload_to_shotgun
+        )
+        thread.finished.connect(event_loop.quit)
+        thread.start()
+        event_loop.exec_()
+
+        # log any errors generated in the thread
+        for e in thread.get_errors():
+            self.__app.log_error(e)
+
+
+class UploaderThread(QtCore.QThread):
+    """
+    Simple worker thread that encapsulates uploading to shotgun.
+    Broken out of the main loop so that the UI can remain responsive
+    even though an upload is happening.
+    """
+
+    def __init__(self, app, version, path_to_movie, thumbnail_path, upload_to_shotgun):
+        QtCore.QThread.__init__(self)
+        self._app = app
+        self._version = version
+        self._path_to_movie = path_to_movie
+        self._thumbnail_path = thumbnail_path
+        self._upload_to_shotgun = upload_to_shotgun
+        self._errors = []
+
+    def get_errors(self):
+        """
+        Returns the errors collected while uploading files to Shotgun.
+
+        :returns:   List of errors
+        :rtype:     [str]
+        """
+        return self._errors
+
+    def run(self):
+        """
+        This function implements what get executed in the UploaderThread.
+        """
+        upload_error = False
+
+        if self._upload_to_shotgun:
+            try:
+                self._app.sgtk.shotgun.upload(
+                    "Version",
+                    self._version["id"],
+                    self._path_to_movie,
+                    "sg_uploaded_movie",
+                )
+            except Exception as e:
+                self._errors.append("Movie upload to Shotgun failed: %s" % e)
+                upload_error = True
+
+        if not self._upload_to_shotgun or upload_error:
+            try:
+                self._app.sgtk.shotgun.upload_thumbnail(
+                    "Version", self._version["id"], self._thumbnail_path
+                )
+            except Exception as e:
+                self._errors.append("Thumbnail upload to Shotgun failed: %s" % e)

--- a/hooks/submitter_sgtk.py
+++ b/hooks/submitter_sgtk.py
@@ -17,6 +17,10 @@ HookBaseClass = sgtk.get_hook_baseclass()
 
 
 class SubmitterSGTK(HookBaseClass):
+    """
+    This hook allow to submit a Version to Shotgun using Shotgun Toolkit.
+    """
+
     def __init__(self, *args, **kwargs):
         super(SubmitterSGTK, self).__init__(*args, **kwargs)
 
@@ -59,16 +63,16 @@ class SubmitterSGTK(HookBaseClass):
         last_frame,
     ):
         """
-        Create a version in Shotgun for this path and linked to this publish.
+        Create a version in Shotgun for a given path and linked to the specified publishes.
 
-        :param path_to_frames: Path to the frame representation.
-        :param path_to_movie: Path to the movie representation.
-        :param thumbnail_path: Path to the thumbnail representing.
-        :param sg_publishes: Published files that have to be linked to the version.
-        :param sg_task: Task that have to be linked to the version.
-        :param description: Description of the version.
-        :param first_frame: Version first frame.
-        :param last_frame: Version last frame.
+        :param str path_to_frames: Path to the frames.
+        :param str path_to_movie: Path to the movie.
+        :param str thumbnail_path: Path to the thumbnail representing the version.
+        :param list(dict) sg_publishes: Published files that have to be linked to the version.
+        :param dict sg_task: Task that have to be linked to the version.
+        :param str description: Description of the version.
+        :param int first_frame: Version first frame.
+        :param int last_frame: Version last frame.
 
         :returns:               Location of the rendered media
         :rtype:                 str
@@ -137,9 +141,9 @@ class SubmitterSGTK(HookBaseClass):
         """
         Upload the required files to Shotgun.
 
-        :param sg_version:      Version to which uploaded files should be linked.
-        :param output_path:     Media to upload to Shotgun.
-        :param thumbnail_path:  Thumbnail to upload to Shotgun.
+        :param dict sg_version:      Version to which uploaded files should be linked.
+        :param str output_path:     Media to upload to Shotgun.
+        :param str thumbnail_path:  Thumbnail to upload to Shotgun.
         """
         # Upload in a new thread and make our own event loop to wait for the
         # thread to finish.

--- a/hooks/tk-maya/render_media.py
+++ b/hooks/tk-maya/render_media.py
@@ -18,6 +18,10 @@ HookBaseClass = sgtk.get_hook_baseclass()
 
 
 class RenderMedia(HookBaseClass):
+    """
+    RenderMedia hook implementation for the tk-maya engine.
+    """
+
     def render(
         self,
         input_path,
@@ -33,22 +37,21 @@ class RenderMedia(HookBaseClass):
         """
         Render the media using the Maya Playblast API
 
-        :param input_path:      Path to the input frames for the movie      (Unused)
-        :param output_path:     Path to the output movie that will be rendered
-        :param width:           Width of the output movie
-        :param height:          Height of the output movie
-        :param first_frame:     The first frame of the sequence of frames.  (Unused)
-        :param last_frame:      The last frame of the sequence of frames.   (Unused)
-        :param version:         Version number to use for the output movie slate and burn-in
-        :param name:            Name to use in the slate for the output movie
-        :param color_space:     Colorspace of the input frames              (Unused)
+        :param str input_path:      Path to the input frames for the movie      (Unused)
+        :param str output_path:     Path to the output movie that will be rendered
+        :param int width:           Width of the output movie
+        :param int height:          Height of the output movie
+        :param int first_frame:     The first frame of the sequence of frames.  (Unused)
+        :param int last_frame:      The last frame of the sequence of frames.   (Unused)
+        :param int version:         Version number to use for the output movie slate and burn-in
+        :param str name:            Name to use in the slate for the output movie
+        :param str color_space:     Colorspace of the input frames              (Unused)
 
         :returns:               Location of the rendered media
         :rtype:                 str
         """
         # For more informations about the playblast API,
         # https://help.autodesk.com/view/MAYAUL/2020/ENU/?guid=__CommandsPython_playblast_html
-
 
         playblast_args = {
             "viewer": False,  # Specify whether a viewer should be launched for the playblast.

--- a/hooks/tk-nuke/render_media.py
+++ b/hooks/tk-nuke/render_media.py
@@ -17,10 +17,11 @@ HookBaseClass = sgtk.get_hook_baseclass()
 
 
 class RenderMedia(HookBaseClass):
+    """
+    RenderMedia hook implementation for the tk-nuke engine.
+    """
+
     def __init__(self):
-        """
-        Construction
-        """
         self.__app = sgtk.platform.current_bundle()
 
         self._burnin_nk = os.path.join(
@@ -60,15 +61,15 @@ class RenderMedia(HookBaseClass):
         """
         Use Nuke to render a movie.
 
-        :param input_path:      Path to the input frames for the movie
-        :param output_path:     Path to the output movie that will be rendered
-        :param width:           Width of the output movie
-        :param height:          Height of the output movie
-        :param first_frame:     The first frame of the sequence of frames.
-        :param last_frame:      The last frame of the sequence of frames.
-        :param version:         Version number to use for the output movie slate and burn-in
-        :param name:            Name to use in the slate for the output movie
-        :param color_space:     Colorspace of the input frames
+        :param str input_path:      Path to the input frames for the movie
+        :param str output_path:     Path to the output movie that will be rendered
+        :param int width:           Width of the output movie
+        :param int height:          Height of the output movie
+        :param int first_frame:     The first frame of the sequence of frames.
+        :param int last_frame:      The last frame of the sequence of frames.
+        :param str version:         Version number to use for the output movie slate and burn-in
+        :param str name:            Name to use in the slate for the output movie
+        :param str color_space:     Colorspace of the input frames
 
         :returns:               Location of the rendered media
         :rtype:                 str
@@ -164,6 +165,12 @@ class RenderMedia(HookBaseClass):
     def __create_scale_node(self, width, height):
         """
         Create the Nuke scale node to resize the content.
+
+        :param int width:           Width of the output movie
+        :param int height:          Height of the output movie
+
+        :returns:               Pre-configured Reformat node
+        :rtype:                 Nuke node
         """
         scale = nuke.nodes.Reformat()
         scale["type"].setValue("to box")
@@ -178,6 +185,11 @@ class RenderMedia(HookBaseClass):
     def __create_output_node(self, path):
         """
         Create the Nuke output node for the movie.
+
+        :param str path:           Path of the output movie
+
+        :returns:               Pre-configured Write node
+        :rtype:                 Nuke node
         """
         # get the Write node settings we'll use for generating the Quicktime
         wn_settings = self.__get_quicktime_settings()
@@ -211,6 +223,9 @@ class RenderMedia(HookBaseClass):
         Allows modifying default codec settings for Quicktime generation.
         Returns a dictionary of settings to be used for the Write Node that generates
         the Quicktime in Nuke.
+
+        :returns:               Codec settings
+        :rtype:                 dict
         """
         settings = {}
         if sys.platform in ["darwin", "win32"]:

--- a/hooks/tk-photoshopcc/render_media.py
+++ b/hooks/tk-photoshopcc/render_media.py
@@ -15,6 +15,10 @@ HookBaseClass = sgtk.get_hook_baseclass()
 
 
 class RenderMedia(HookBaseClass):
+    """
+    RenderMedia hook implementation for the tk-photoshopcc engine.
+    """
+
     def pre_render(
         self,
         input_path,
@@ -30,15 +34,15 @@ class RenderMedia(HookBaseClass):
         """
         Callback executed before the media rendering
 
-        :param path:            Path to the input frames for the movie
-        :param output_path:     Path to the output movie that will be rendered
-        :param width:           Width of the output movie
-        :param height:          Height of the output movie
-        :param first_frame:     The first frame of the sequence of frames.
-        :param last_frame:      The last frame of the sequence of frames.
-        :param version:         Version number to use for the output movie slate and burn-in
-        :param name:            Name to use in the slate for the output movie
-        :param color_space:     Colorspace of the input frames
+        :param str path:            Path to the input frames for the movie
+        :param str output_path:     Path to the output movie that will be rendered
+        :param int width:           Width of the output movie
+        :param int height:          Height of the output movie
+        :param int first_frame:     The first frame of the sequence of frames.
+        :param int last_frame:      The last frame of the sequence of frames.
+        :param int version:         Version number to use for the output movie slate and burn-in
+        :param str name:            Name to use in the slate for the output movie
+        :param str color_space:     Colorspace of the input frames
 
         :returns:               Location of the rendered media
         :rtype:                 str
@@ -64,15 +68,15 @@ class RenderMedia(HookBaseClass):
         """
         Render the media using the engine implementation of ``export_as_jpeg``
 
-        :param input_path:      Path to the input frames for the movie      (Unused)
-        :param output_path:     Path to the output movie that will be rendered
-        :param width:           Width of the output movie                   (Unused)
-        :param height:          Height of the output movie                  (Unused)
-        :param first_frame:     The first frame of the sequence of frames.  (Unused)
-        :param last_frame:      The last frame of the sequence of frames.   (Unused)
-        :param version:         Version number to use for the output movie slate and burn-in
-        :param name:            Name to use in the slate for the output movie
-        :param color_space:     Colorspace of the input frames              (Unused)
+        :param str input_path:      Path to the input frames for the movie      (Unused)
+        :param str output_path:     Path to the output movie that will be rendered
+        :param int width:           Width of the output movie                   (Unused)
+        :param int height:          Height of the output movie                  (Unused)
+        :param int first_frame:     The first frame of the sequence of frames.  (Unused)
+        :param int last_frame:      The last frame of the sequence of frames.   (Unused)
+        :param int version:         Version number to use for the output movie slate and burn-in
+        :param str name:            Name to use in the slate for the output movie
+        :param str color_space:     Colorspace of the input frames              (Unused)
 
         :returns:               Location of the rendered media
         :rtype:                 str

--- a/info.yml
+++ b/info.yml
@@ -86,7 +86,7 @@ configuration:
     submitter_hook:
         type: hook
         description: Implements how media get sent to Shotgun
-        default_value: '{self}/submitter_create.py'
+        default_value: '{self}/submitter_sgtk.py'
 
 # the Shotgun fields that this app needs in order to operate correctly
 requires_shotgun_fields:

--- a/info.yml
+++ b/info.yml
@@ -17,6 +17,22 @@ configuration:
         default_value: Send for review
         description: Specify the name that should be used in menus and the main
 
+    upload_to_shotgun:
+        type: bool
+        default_value: true
+        description: Should the movie being created be uploaded to Shotgun
+                     as a version or just kept on disk? Disabling this as well
+                     as the store_on_disk option effectively disables the whole
+                     tool.
+
+    store_on_disk:
+        type: bool
+        default_value: true
+        description: Should the movie being created be kept on disk? Disabling
+                     this as well as the upload_to_shotgun option will
+                     effectively disable the whole tool.
+
+
     movie_path_template:
         allows_empty: True
         type: template
@@ -64,8 +80,13 @@ configuration:
 
     render_media_hook:
         type: hook
-        description: TODO!!!
+        description: Implements how media get generated while this app is running.
         default_value: '{self}/render_media.py:{self}/{engine_name}/render_media.py'
+
+    submitter_hook:
+        type: hook
+        description: Implements how media get sent to Shotgun
+        default_value: '{self}/submitter_create.py'
 
 # the Shotgun fields that this app needs in order to operate correctly
 requires_shotgun_fields:


### PR DESCRIPTION
JIRA: VMR-2289

DESCRIPTION

In order to not break the previous pipelines, the last changes got isolated
inside of hooks. Configs will have to specify that they want to use the new
implementation of the version submission.

The issue was that the app is still used in a Nuke workflow with the
tk-multi-publish2 app and it not be great to break pipelines and change
the expected behaviour on an updates.

Instead, I implemented the new changes inside of hooks and the person adding
the app to a config can choose which implementation to use