### PR TITLE
Additional changes to fix the Nuke workflow

### DIFF
--- a/app.py
+++ b/app.py
@@ -35,19 +35,22 @@ class MultiReviewSubmissionApp(sgtk.platform.Application):
 
         display_name = self.get_setting("display_name")
 
-        menu_caption = "%s..." % display_name
-        menu_options = {
-            "short_name": "send_for_review",
-            "description": "Send a version for review using Shotgun Create",
-            # dark themed icon for engines that recognize this format
-            "icons": {
-                "dark": {"png": os.path.join(self.disk_location, "icon_256_dark.png")}
-            },
-        }
+        if display_name:
+            menu_caption = "%s..." % display_name
+            menu_options = {
+                "short_name": "send_for_review",
+                "description": "Send a version for review using Shotgun Create",
+                # dark themed icon for engines that recognize this format
+                "icons": {
+                    "dark": {
+                        "png": os.path.join(self.disk_location, "icon_256_dark.png")
+                    }
+                },
+            }
 
-        self.engine.register_command(
-            menu_caption, lambda: app.send_for_review(), menu_options
-        )
+            self.engine.register_command(
+                menu_caption, lambda: app.send_for_review(), menu_options
+            )
 
     @property
     def context_change_allowed(self):
@@ -87,10 +90,11 @@ class MultiReviewSubmissionApp(sgtk.platform.Application):
         :param color_space:     The colorspace of the rendered frames
 
         :returns:               The Version Shotgun entity dictionary that was created.
+        :rtype:                 dict
         """
         app = self.import_module("tk_multi_reviewsubmission")
 
-        app.render_and_submit_version(
+        return app.render_and_submit_version(
             template,
             fields,
             first_frame,

--- a/app.py
+++ b/app.py
@@ -35,6 +35,8 @@ class MultiReviewSubmissionApp(sgtk.platform.Application):
 
         display_name = self.get_setting("display_name")
 
+        # Only register the command to the engine if the display name is explicitely added to the config.
+        # There's cases where someone would want to have this app in his environment without the menu item.
         if display_name:
             menu_caption = "%s..." % display_name
             menu_options = {

--- a/hooks/submitter_create.py
+++ b/hooks/submitter_create.py
@@ -113,5 +113,5 @@ class SubmitterCreate(HookBaseClass):
 
         client.call_server_method("sgc_open_version_draft", version_draft_args)
 
-        # Beause of the asynchronous nature of this hook. It doesn't returns any Version Shotgun entity dictionary.
+        # Because of the asynchronous nature of this hook. It doesn't returns any Version Shotgun entity dictionary.
         return None

--- a/hooks/submitter_create.py
+++ b/hooks/submitter_create.py
@@ -40,7 +40,7 @@ class SubmitterCreate(HookBaseClass):
         """
 
         if not self.__create_client_module.is_create_installed():
-            self.log_warning("Shotgun Create is not installed.")
+            self.__app.log_warning("Shotgun Create is not installed.")
             self.__create_client_module.open_shotgun_create_download_page(
                 self.__app.sgtk.shotgun
             )

--- a/hooks/submitter_create.py
+++ b/hooks/submitter_create.py
@@ -75,8 +75,10 @@ class SubmitterCreate(HookBaseClass):
         Note: Shotgun Create will create the thumbnail for the movie passed in and
         will inspect the media to get the first and last frame, so these parameters are ignored.
 
-        :returns:               Location of the rendered media
-        :rtype:                 str
+        :returns:               The Version Shotgun entity dictionary that was created.
+        :rtype:                 dict
+
+        Beause of the asynchronous nature of this hook. It doesn't returns any Version Shotgun entity dictionary.
         """
 
         path_to_media = path_to_movie or path_to_frames
@@ -106,3 +108,6 @@ class SubmitterCreate(HookBaseClass):
             version_draft_args["version_data"]["description"] = description
 
         client.call_server_method("sgc_open_version_draft", version_draft_args)
+
+        # Beause of the asynchronous nature of this hook. It doesn't returns any Version Shotgun entity dictionary.
+        return None

--- a/hooks/submitter_sgtk.py
+++ b/hooks/submitter_sgtk.py
@@ -74,8 +74,8 @@ class SubmitterSGTK(HookBaseClass):
         :param int first_frame: Version first frame.
         :param int last_frame: Version last frame.
 
-        :returns:               Location of the rendered media
-        :rtype:                 str
+        :returns:               The Version Shotgun entity dictionary that was created.
+        :rtype:                 dict
         """
 
         # get current shotgun user

--- a/hooks/submitter_sgtk.py
+++ b/hooks/submitter_sgtk.py
@@ -43,7 +43,7 @@ class SubmitterSGTK(HookBaseClass):
         """
 
         if not self._upload_to_shotgun and not self._store_on_disk:
-            self.log_warning(
+            self.__app.log_warning(
                 "App is not configured to store images on disk nor upload to shotgun!"
             )
 

--- a/hooks/tk-nuke/render_media.py
+++ b/hooks/tk-nuke/render_media.py
@@ -21,8 +21,10 @@ class RenderMedia(HookBaseClass):
     RenderMedia hook implementation for the tk-nuke engine.
     """
 
-    def __init__(self):
-        self.__app = sgtk.platform.current_bundle()
+    def __init__(self, *args, **kwargs):
+        super(RenderMedia, self).__init__(*args, **kwargs)
+
+        self.__app = self.parent
 
         self._burnin_nk = os.path.join(
             self.__app.disk_location, "resources", "burnin.nk"

--- a/info.yml
+++ b/info.yml
@@ -14,7 +14,7 @@
 configuration:
     display_name:
         type: str
-        default_value: Send for review
+        default_value: ""
         description: Specify the name that should be used in menus and the main
 
     upload_to_shotgun:
@@ -100,9 +100,7 @@ requires_shotgun_version:
 requires_core_version: "v0.14.0"
 requires_engine_version:
 
-# For now this app is only compatible with Nuke.
 supported_engines:
 
 # the frameworks required to run this app
 frameworks:
-    - {"name": "tk-framework-desktopclient", "version": "v0.x.x"}

--- a/python/tk_multi_reviewsubmission/__init__.py
+++ b/python/tk_multi_reviewsubmission/__init__.py
@@ -16,9 +16,16 @@ logger = sgtk.platform.get_logger(__name__)
 
 
 def send_for_review():
+    """
+    Main application entry point to be called by the engine command.
+
+    :returns:               The Version Shotgun entity dictionary that was created.
+    :rtype:                 dict
+    """
+
     try:
         action = Actions()
-        action.render_and_submit_version()
+        return action.render_and_submit_version()
     except RuntimeError as e:
         logger.error(str(e))
 
@@ -37,9 +44,27 @@ def render_and_submit_version(
     *args,
     **kwargs
 ):
+    """
+    Main application entry point to be called by other applications / hooks.
+
+    :param template:        The template defining the path where frames should be found.
+    :param fields:          Dictionary of fields to be used to fill out the template with.
+    :param first_frame:     The first frame of the sequence of frames.
+    :param last_frame:      The last frame of the sequence of frames.
+    :param sg_publishes:    A list of shotgun published file objects to link the publish against.
+    :param sg_task:         A Shotgun task object to link against. Can be None.
+    :param comment:         A description to add to the Version in Shotgun.
+    :param thumbnail_path:  The path to a thumbnail to use for the version when the movie isn't
+                            being uploaded to Shotgun (this is set in the config)
+    :param progress_cb:     A callback to report progress with.
+    :param color_space:     The colorspace of the rendered frames
+
+    :returns:               The Version Shotgun entity dictionary that was created.
+    :rtype:                 dict
+    """
     try:
         action = Actions()
-        action.render_and_submit_version(
+        return action.render_and_submit_version(
             template,
             fields,
             first_frame,

--- a/python/tk_multi_reviewsubmission/actions.py
+++ b/python/tk_multi_reviewsubmission/actions.py
@@ -15,9 +15,6 @@ import copy
 class Actions(object):
     def __init__(self):
         self.__app = sgtk.platform.current_bundle()
-        self.__create_client_module = sgtk.platform.import_framework(
-            "tk-framework-desktopclient", "create_client"
-        )
 
         can_submit = self.__app.execute_hook_method(
             key="submitter_hook", method_name="can_submit", base_class=None,
@@ -55,6 +52,9 @@ class Actions(object):
                                 being uploaded to Shotgun (this is set in the config)
         :param progress_cb:     A callback to report progress with.
         :param color_space:     The colorspace of the rendered frames
+
+        :returns:               The Version Shotgun entity dictionary that was created.
+        :rtype:                 dict
         """
 
         # Wrap the method so we don't have to worry about process_cb being None
@@ -156,7 +156,7 @@ class Actions(object):
             "last_frame": last_frame,
         }
 
-        self.__app.execute_hook_method(
+        version = self.__app.execute_hook_method(
             key="submitter_hook",
             method_name="submit_version",
             base_class=None,
@@ -169,3 +169,5 @@ class Actions(object):
         except Exception:
             # ingore any errors. ex: metrics logging not supported
             pass
+
+        return version


### PR DESCRIPTION
DESCRIPTION
* Do not show the menu item if the display name is not defined in the config.
* Correctly initialize the tk-nuke render_media.py hook.
* Remove unrequired dependecies to the tk-framework-desktopclient (only
* required in the submitter_create.py hook)