### PR TITLE
Show message dialogs on top of everything

### DIFF
--- a/hooks/submitter_create.py
+++ b/hooks/submitter_create.py
@@ -10,7 +10,7 @@
 
 
 import sgtk
-from sgtk.platform.qt import QtGui
+from sgtk.platform.qt import QtCore, QtGui
 
 HookBaseClass = sgtk.get_hook_baseclass()
 
@@ -41,9 +41,16 @@ class SubmitterCreate(HookBaseClass):
         """
 
         if not self.__create_client_module.is_create_installed():
-            QtGui.QMessageBox.warning(
-                None, "Cannot submit to Shotgun", "Shotgun Create is not installed!",
-            )
+
+            QtGui.QMessageBox(
+                QtGui.QMessageBox.Warning,
+                "Cannot submit to Shotgun",
+                "Shotgun Create is not installed!",
+                flags=QtCore.Qt.Dialog
+                | QtCore.Qt.MSWindowsFixedSizeDialogHint
+                | QtCore.Qt.WindowStaysOnTopHint
+                | QtCore.Qt.X11BypassWindowManagerHint,
+            ).exec_()
 
             self.__create_client_module.open_shotgun_create_download_page(
                 self.__app.sgtk.shotgun

--- a/hooks/submitter_sgtk.py
+++ b/hooks/submitter_sgtk.py
@@ -39,11 +39,16 @@ class SubmitterSGTK(HookBaseClass):
         """
 
         if not self._upload_to_shotgun and not self._store_on_disk:
-            QtGui.QMessageBox.warning(
-                None,
+            QtGui.QMessageBox(
+                QtGui.QMessageBox.Warning,
                 "Cannot submit to Shotgun",
                 "Application is not configured to store images on disk or upload to shotgun!",
-            )
+                flags=QtCore.Qt.Dialog
+                | QtCore.Qt.MSWindowsFixedSizeDialogHint
+                | QtCore.Qt.WindowStaysOnTopHint
+                | QtCore.Qt.X11BypassWindowManagerHint,
+            ).exec_()
+
             return False
 
         return True

--- a/hooks/tk-photoshopcc/render_media.py
+++ b/hooks/tk-photoshopcc/render_media.py
@@ -10,7 +10,7 @@
 
 
 import sgtk
-from sgtk.platform.qt import QtGui
+from sgtk.platform.qt import QtCore, QtGui
 
 HookBaseClass = sgtk.get_hook_baseclass()
 
@@ -52,9 +52,15 @@ class RenderMedia(HookBaseClass):
         engine = sgtk.platform.current_engine()
 
         if not engine.adobe.get_active_document():
-            QtGui.QMessageBox.warning(
-                None, "Unable to render", "No active document found.",
-            )
+            QtGui.QMessageBox(
+                QtGui.QMessageBox.Warning,
+                "Unable to render",
+                "No active document found.",
+                flags=QtCore.Qt.Dialog
+                | QtCore.Qt.MSWindowsFixedSizeDialogHint
+                | QtCore.Qt.WindowStaysOnTopHint
+                | QtCore.Qt.X11BypassWindowManagerHint,
+            ).exec_()
 
             raise RuntimeError("No active document found.")
 


### PR DESCRIPTION
DESCRIPTION

On DCC like Photoshop, the window was being shown behind the DCC. It's bad
because these dialogues hold the python interpreter execution until it's closed.