### PR TITLE
Re-introduce the new_version_status setting

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -57,12 +57,12 @@ configuration:
         type: int
         default_value: 1080
         description: The height of the rendered movie file
-        
-    new_version_status:		
-         type: str		
-         default_value: rev		
+
+    new_version_status:
+         type: str
+         default_value: rev
          description: The value to use for a new Version's status.
-         
+
     version_number_padding:
         type: int
         default_value: 3

--- a/info.yml
+++ b/info.yml
@@ -57,7 +57,12 @@ configuration:
         type: int
         default_value: 1080
         description: The height of the rendered movie file
-
+        
+    new_version_status:		
+         type: str		
+         default_value: rev		
+         description: The value to use for a new Version's status.
+         
     version_number_padding:
         type: int
         default_value: 3


### PR DESCRIPTION
This setting entry got lost during refactoring. It's still being used here: https://github.com/shotgunsoftware/tk-multi-reviewsubmission/blob/master/hooks/submitter_sgtk.py#L98