### PR TITLE
Fix arguments passed in render_and_submit_version

### DIFF
--- a/app.py
+++ b/app.py
@@ -106,7 +106,7 @@ class MultiReviewSubmissionApp(sgtk.platform.Application):
             comment,
             thumbnail_path,
             progress_cb,
-            color_space=None,
+            color_space,
             *args,
             **kwargs
         )


### PR DESCRIPTION
The definition of render_and_submit_version never passed the given value of color_space, the value was hardcoded to None.
I removed the value forced to None.